### PR TITLE
Nullstill alle valg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bekk/spire-nav-brevgenerator",
-    "version": "1.0.15",
+    "version": "1.0.18",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bekk/spire-nav-brevgenerator",
-            "version": "1.0.15",
+            "version": "1.0.18",
             "license": "ISC",
             "dependencies": {
                 "@babel/preset-env": "^7.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bekk/spire-nav-brevgenerator",
-    "version": "1.0.18",
+    "version": "1.0.20",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bekk/spire-nav-brevgenerator",
-            "version": "1.0.18",
+            "version": "1.0.20",
             "license": "ISC",
             "dependencies": {
                 "@babel/preset-env": "^7.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bekk/spire-nav-brevgenerator",
-    "version": "1.0.17",
+    "version": "1.0.18",
     "description": "",
     "main": "./brevGenerator.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bekk/spire-nav-brevgenerator",
-    "version": "1.0.18",
+    "version": "1.0.20",
     "description": "",
     "main": "./brevGenerator.js",
     "scripts": {

--- a/src/komponenter/delseksjon.tsx
+++ b/src/komponenter/delseksjon.tsx
@@ -27,9 +27,16 @@ import {
 interface seksjonProps {
     delseksjon: SanityDelseksjon;
     delseksjonIndeks: number;
+    skalAlleValgNullstilles: boolean;
+    setSkalAlleValgNullstilles: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export function Delseksjon({ delseksjon, delseksjonIndeks }: seksjonProps) {
+export function Delseksjon({
+    delseksjon,
+    delseksjonIndeks,
+    skalAlleValgNullstilles,
+    setSkalAlleValgNullstilles,
+}: seksjonProps) {
     const {
         avsnittState,
         avsnittDispatch,
@@ -63,6 +70,16 @@ export function Delseksjon({ delseksjon, delseksjonIndeks }: seksjonProps) {
             }
         }
     }, [delseksjon]);
+
+    useEffect(() => {
+        if (skalAlleValgNullstilles) {
+            const nyFritekstTabell = innholdTilFritekstTabell(delseksjon.innhold);
+            settFritekstTabell(nyFritekstTabell);
+            settFritekst(dobbelTabellTilStreng(nyFritekstTabell));
+
+            setSkalAlleValgNullstilles(false);
+        }
+    }, [skalAlleValgNullstilles]);
 
     const oppdaterFlettefeltFraDropdowns = (nyeFlettefelt: flettefelt[], indeks: number) => {
         const flettefeltKopi = [...flettefelt];

--- a/src/komponenter/seksjon.tsx
+++ b/src/komponenter/seksjon.tsx
@@ -6,9 +6,16 @@ import '../stiler/seksjon.css';
 interface SeksjonsProps {
     seksjon: SanitySeksjon;
     seksjonStartIndeks: number;
+    skalAlleValgNullstilles: boolean;
+    setSkalAlleValgNullstilles: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export function Seksjon({ seksjon, seksjonStartIndeks }: SeksjonsProps) {
+export function Seksjon({
+    seksjon,
+    seksjonStartIndeks,
+    skalAlleValgNullstilles,
+    setSkalAlleValgNullstilles,
+}: SeksjonsProps) {
     return (
         <div className="seksjon">
             <h1>{seksjon.seksjonstittel}</h1>
@@ -17,6 +24,8 @@ export function Seksjon({ seksjon, seksjonStartIndeks }: SeksjonsProps) {
                     delseksjon={delseksjon}
                     delseksjonIndeks={seksjonStartIndeks + indeks}
                     key={indeks}
+                    skalAlleValgNullstilles={skalAlleValgNullstilles}
+                    setSkalAlleValgNullstilles={setSkalAlleValgNullstilles}
                 />
             ))}
         </div>

--- a/src/komponenter/skjema.tsx
+++ b/src/komponenter/skjema.tsx
@@ -87,21 +87,25 @@ export function Skjema({ brevmaler, sanityBaseURL }: SkjemaProps) {
                     </option>
                 ))}
             </Select>
-            {/* <Button onClick={mellomlagreBrev} className={'mellomlagre-button'}>
-                Mellomlagre brev
-            </Button> */}
-            {gjeldendeBrevmal !== null &&
-                gjeldendeBrevmal.seksjoner.map((seksjon: SanitySeksjon, indeks: number) => {
-                    const seksjonKomponent = (
-                        <Seksjon
-                            seksjon={seksjon as SanitySeksjon}
-                            key={indeks}
-                            seksjonStartIndeks={delseksjonTeller}
-                        />
-                    );
-                    delseksjonTeller += (seksjon as SanitySeksjon).delseksjoner.length;
-                    return seksjonKomponent;
-                })}
+            {gjeldendeBrevmal !== null && (
+                <>
+                    {gjeldendeBrevmal.seksjoner.map((seksjon: SanitySeksjon, indeks: number) => {
+                        const seksjonKomponent = (
+                            <Seksjon
+                                seksjon={seksjon as SanitySeksjon}
+                                key={indeks}
+                                seksjonStartIndeks={delseksjonTeller}
+                            />
+                        );
+                        delseksjonTeller += (seksjon as SanitySeksjon).delseksjoner.length;
+                        return seksjonKomponent;
+                    })}
+                    <div className="skjema-knapper">
+                        <Button variant="secondary">Nullstill valg</Button>
+                        <Button onClick={mellomlagreBrev}>Mellomlagre brev</Button>
+                    </div>
+                </>
+            )}
         </div>
     );
 }

--- a/src/komponenter/skjema.tsx
+++ b/src/komponenter/skjema.tsx
@@ -8,7 +8,7 @@ import { Seksjon } from './seksjon';
 import '../stiler/skjema.css';
 import {
     finnInitielleAvsnittOgAntallDelseksjoner,
-    finnInitielMellomlagringDelseksjonState,
+    finnInitiellMellomlagringDelseksjonState,
 } from '../utils/skjemaUtils';
 
 interface SkjemaProps {
@@ -45,28 +45,28 @@ export function Skjema({ brevmaler, sanityBaseURL }: SkjemaProps) {
                     skalAvsnittInkluderesDispatch(mellomlagretBrev.inkluderingsbrytere);
                     mellomlagringDelseksjonerDispatch(mellomlagretBrev.delseksjoner);
                 } else {
-                    initierContext(res.seksjoner);
+                    initialisereContext(res.seksjoner);
                 }
             }
         });
     }, [gjeldendeBrevmalId]);
 
-    const initierContext = (seksjoner: SanitySeksjon[]) => {
+    const initialisereContext = (seksjoner: SanitySeksjon[]) => {
         const { nyeAvsnitt, antallDelSeksjoner } =
             finnInitielleAvsnittOgAntallDelseksjoner(seksjoner);
         const nyeInkluderingsBrytere: boolean[] = new Array(antallDelSeksjoner).fill(true);
-        const initelMellomlagringDelseksjonState =
-            finnInitielMellomlagringDelseksjonState(seksjoner);
+        const initellMellomlagringDelseksjonState =
+            finnInitiellMellomlagringDelseksjonState(seksjoner);
 
         avsnittDispatch(nyeAvsnitt);
         skalAvsnittInkluderesDispatch(nyeInkluderingsBrytere);
-        mellomlagringDelseksjonerDispatch(initelMellomlagringDelseksjonState);
+        mellomlagringDelseksjonerDispatch(initellMellomlagringDelseksjonState);
     };
 
     const nullStillAlleValg = () => {
         setSkalAlleValgNullstilles(true);
         if (gjeldendeBrevmal !== null) {
-            initierContext(gjeldendeBrevmal.seksjoner);
+            initialisereContext(gjeldendeBrevmal.seksjoner);
         }
     };
 

--- a/src/komponenter/skjema.tsx
+++ b/src/komponenter/skjema.tsx
@@ -34,24 +34,27 @@ export function Skjema({ brevmaler, sanityBaseURL }: SkjemaProps) {
         React.useContext(MellomlagringContext);
 
     useEffect(() => {
-        setSkalAlleValgNullstilles(false);
-        hentBrevmal(sanityBaseURL, gjeldendeBrevmalId).then((res: SanityBrevmalMedSeksjoner) => {
-            if (res !== null && res.seksjoner.length > 0) {
-                setGjeldendeBrevmal(res);
-                brevmalTittelDispatch(res.brevmaloverskrift);
-                const mellomlagretBrev = hentMellomlagretBrev(res._id);
+        const hentOgPopulerData = async () => {
+            const brevmal = await hentBrevmal(sanityBaseURL, gjeldendeBrevmalId);
+            if (brevmal) {
+                const mellomlagretBrev = await hentMellomlagretBrev(brevmal._id);
+
+                setGjeldendeBrevmal(brevmal);
+                brevmalTittelDispatch(brevmal.brevmaloverskrift);
+
                 if (mellomlagretBrev !== undefined) {
                     avsnittDispatch(mellomlagretBrev.avsnitt);
                     skalAvsnittInkluderesDispatch(mellomlagretBrev.inkluderingsbrytere);
                     mellomlagringDelseksjonerDispatch(mellomlagretBrev.delseksjoner);
                 } else {
-                    initialisereContext(res.seksjoner);
+                    initialiserContext(brevmal.seksjoner);
                 }
             }
-        });
+        };
+        hentOgPopulerData();
     }, [gjeldendeBrevmalId]);
 
-    const initialisereContext = (seksjoner: SanitySeksjon[]) => {
+    const initialiserContext = (seksjoner: SanitySeksjon[]) => {
         const { nyeAvsnitt, antallDelSeksjoner } =
             finnInitielleAvsnittOgAntallDelseksjoner(seksjoner);
         const nyeInkluderingsBrytere: boolean[] = new Array(antallDelSeksjoner).fill(true);
@@ -66,7 +69,7 @@ export function Skjema({ brevmaler, sanityBaseURL }: SkjemaProps) {
     const nullStillAlleValg = () => {
         setSkalAlleValgNullstilles(true);
         if (gjeldendeBrevmal !== null) {
-            initialisereContext(gjeldendeBrevmal.seksjoner);
+            initialiserContext(gjeldendeBrevmal.seksjoner);
         }
     };
 

--- a/src/komponenter/skjema.tsx
+++ b/src/komponenter/skjema.tsx
@@ -101,6 +101,12 @@ export function Skjema({ brevmaler, sanityBaseURL }: SkjemaProps) {
             </Select>
             {gjeldendeBrevmal !== null && (
                 <>
+                    <div className="skjema-knapper">
+                        <Button variant="secondary" onClick={nullStillAlleValg}>
+                            Nullstill valg
+                        </Button>
+                        <Button onClick={mellomlagreBrev}>Mellomlagre brev</Button>
+                    </div>
                     {gjeldendeBrevmal.seksjoner.map((seksjon: SanitySeksjon, indeks: number) => {
                         const seksjonKomponent = (
                             <Seksjon
@@ -114,12 +120,6 @@ export function Skjema({ brevmaler, sanityBaseURL }: SkjemaProps) {
                         delseksjonTeller += (seksjon as SanitySeksjon).delseksjoner.length;
                         return seksjonKomponent;
                     })}
-                    <div className="skjema-knapper">
-                        <Button variant="secondary" onClick={nullStillAlleValg}>
-                            Nullstill valg
-                        </Button>
-                        <Button onClick={mellomlagreBrev}>Mellomlagre brev</Button>
-                    </div>
                 </>
             )}
         </div>

--- a/src/stiler/skjema.css
+++ b/src/stiler/skjema.css
@@ -5,6 +5,12 @@
 }
 
 .mellomlagre-button {
-	margin-top: 20px;
-	width: 100%;
+    margin-top: 20px;
+    width: 100%;
+}
+
+.skjema-knapper {
+    margin-top: 20px;
+    display: flex;
+    justify-content: space-between;
 }

--- a/src/utils/skjemaUtils.ts
+++ b/src/utils/skjemaUtils.ts
@@ -1,52 +1,52 @@
-import { mellomlagringDelseksjon, mellomlagringDropdown } from "../typer/mellomlagring";
-import { SanityDropdown, SanitySeksjon, SanityTekstObjekt } from "../typer/sanity";
-import { finnFlettefeltITekst } from "./flettefeltUtils";
-import { erInnholdDropdown, sanityBlocktekstToHtml } from "./sanityUtils";
+import { mellomlagringDelseksjon, mellomlagringDropdown } from '../typer/mellomlagring';
+import { SanityDropdown, SanitySeksjon, SanityTekstObjekt } from '../typer/sanity';
+import { finnFlettefeltITekst } from './flettefeltUtils';
+import { erInnholdDropdown, sanityBlocktekstToHtml } from './sanityUtils';
 
 const finnInitelleAvsnittISeksjon = (seksjon: SanitySeksjon): string[] => {
+    return seksjon.delseksjoner.map((delseksjon) => {
+        let nyFritekst = '';
+        delseksjon.innhold.forEach((innhold: SanityDropdown | SanityTekstObjekt) => {
+            if ((innhold as SanityTekstObjekt).tekstTittel !== undefined) {
+                nyFritekst += sanityBlocktekstToHtml(innhold as SanityTekstObjekt).join(' ');
+            }
+        });
+        return nyFritekst;
+    });
+};
+
+export const finnInitielleAvsnittOgAntallDelseksjoner = (
+    seksjoner: SanitySeksjon[]
+): { nyeAvsnitt: string[]; antallDelSeksjoner: number } => {
+    let antallDelSeksjoner = 0;
+    const nyeAvsnitt: string[] = seksjoner.flatMap((seksjon) => {
+        antallDelSeksjoner += seksjon.delseksjoner.length;
+        return finnInitelleAvsnittISeksjon(seksjon);
+    });
+    return { nyeAvsnitt, antallDelSeksjoner };
+};
+
+export const finnInitiellMellomlagringDelseksjonState = (
+    seksjoner: SanitySeksjon[]
+): mellomlagringDelseksjon[] => {
+    return seksjoner.flatMap((seksjon) => {
         return seksjon.delseksjoner.map((delseksjon) => {
-            let nyFritekst = '';
-            delseksjon.innhold.forEach((innhold: SanityDropdown | SanityTekstObjekt) => {
-                if ((innhold as SanityTekstObjekt).tekstTittel !== undefined) {
-                    nyFritekst += sanityBlocktekstToHtml(innhold as SanityTekstObjekt).join(' ');
+            const innhold = delseksjon.innhold.map((innhold): string[] | mellomlagringDropdown => {
+                if (erInnholdDropdown(innhold)) {
+                    return {
+                        valgVerdi: undefined,
+                        flettefelt: [],
+                    };
+                } else {
+                    let antallFlettefelt = 0;
+                    (innhold as SanityTekstObjekt).tekst.forEach((tekst) => {
+                        const flettefelt = finnFlettefeltITekst(tekst);
+                        antallFlettefelt += flettefelt.length;
+                    });
+                    return Array(antallFlettefelt).fill('');
                 }
             });
-            return nyFritekst;
+            return { innhold: innhold, fritekstTabell: [] };
         });
-    };
-
-export const finnInitielleAvsnittOgAntallDelseksjoner = (seksjoner: SanitySeksjon[]): {nyeAvsnitt: string[], antallDelSeksjoner: number} => {
-        let antallDelSeksjoner = 0;
-        const nyeAvsnitt: string[] = seksjoner.flatMap((seksjon) => {
-            antallDelSeksjoner += seksjon.delseksjoner.length;
-            return finnInitelleAvsnittISeksjon(seksjon);
-        });
-        return { nyeAvsnitt, antallDelSeksjoner };
-    };
-
-export const finnInitielMellomlagringDelseksjonState = (seksjoner: SanitySeksjon[]): mellomlagringDelseksjon[] => {
-    return seksjoner.flatMap(
-        (seksjon) => {
-            return seksjon.delseksjoner.map((delseksjon) => {
-                const innhold = delseksjon.innhold.map(
-                    (innhold): string[] | mellomlagringDropdown => {
-                        if (erInnholdDropdown(innhold)) {
-                            return {
-                                valgVerdi: undefined,
-                                flettefelt: [],
-                            };
-                        } else {
-                            let antallFlettefelt = 0;
-                            (innhold as SanityTekstObjekt).tekst.forEach((tekst) => {
-                                const flettefelt = finnFlettefeltITekst(tekst);
-                                antallFlettefelt += flettefelt.length;
-                            });
-                            return Array(antallFlettefelt).fill('');
-                        }
-                    }
-                );
-                return { innhold: innhold, fritekstTabell: [] };
-            });
-        }
-    );
+    });
 };


### PR DESCRIPTION
# Problem 🤯
Saksbehandler har ingen mulighet til å fjerne alle valg som er tatt uten å bytte frem og tilbake mellom brevmaler. Og om brevmalen er mellomlagret er det ikke mulig at all. 

# Løsning ✨
Legge til en nullstill-knapp som fjerner alle valg som er gjort i brevmalen. Når knappen trykkes på settes alle dropdowner tilbake til "velg et alternativ" og den tilhørende teksten fjernes fra fritekstfeltet. 