### PR TITLE
Style tabeller i pdf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bekk/spire-nav-brevgenerator",
-    "version": "1.0.27",
+    "version": "1.0.30",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bekk/spire-nav-brevgenerator",
-            "version": "1.0.27",
+            "version": "1.0.30",
             "license": "ISC",
             "dependencies": {
                 "@babel/preset-env": "^7.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@bekk/spire-nav-brevgenerator",
-    "version": "1.0.26",
+    "version": "1.0.27",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@bekk/spire-nav-brevgenerator",
-            "version": "1.0.26",
+            "version": "1.0.27",
             "license": "ISC",
             "dependencies": {
                 "@babel/preset-env": "^7.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bekk/spire-nav-brevgenerator",
-    "version": "1.0.26",
+    "version": "1.0.27",
     "description": "",
     "main": "./brevGenerator.js",
     "scripts": {

--- a/src/stiler/css.ts
+++ b/src/stiler/css.ts
@@ -33,4 +33,21 @@ export default `
     display: inline-block;
 	margin-top: 40mm;
 }
+
+table,
+th,
+td {
+    border: 1px solid;
+    font-size: 1.2vmin;
+}
+
+th,
+td {
+    padding: 1mm 2mm;
+}
+
+table {
+    border-collapse: collapse;
+    width: 150mm;
+}
 `;


### PR DESCRIPTION
Lagt til styling av tabell i generert pdf. Legger ved bilde av hvordan det ser ut når man genererer en pdf nå: 

<img width="768" alt="image" src="https://user-images.githubusercontent.com/46678893/194899916-d6ee4f01-c7b8-4652-9a08-fe9f7c602261.png">
